### PR TITLE
Potential fix for code scanning alert no. 2046: Uncontrolled data used in path expression

### DIFF
--- a/raft_toolkit/core/raft_engine.py
+++ b/raft_toolkit/core/raft_engine.py
@@ -188,6 +188,7 @@ class RaftEngine:
         logger.info("Input validation completed successfully")
 
     def get_processing_preview(self, data_path: Optional[Path] = None) -> Dict[str, Any]:
+        safe_root = Path("/safe/root/directory")
         """
         Get a preview of what would be processed without actually processing.
 
@@ -205,8 +206,9 @@ class RaftEngine:
                 raise ValueError("No data path specified")
             data_path = Path(config_datapath) if isinstance(config_datapath, str) else config_datapath
 
-        if not data_path.exists():
-            raise FileNotFoundError(f"Input data path does not exist: {data_path}")
+        normalized_path = Path(os.path.normpath(data_path))
+        if not normalized_path.exists() or not str(normalized_path).startswith(str(safe_root)):
+            raise FileNotFoundError(f"Invalid or unsafe input data path: {normalized_path}")
 
         preview = {
             "input_path": str(data_path),

--- a/raft_toolkit/web/app.py
+++ b/raft_toolkit/web/app.py
@@ -291,8 +291,8 @@ async def get_preview(
     """Get a preview of what would be processed."""
     try:
         # Validate file exists
-        normalized_path = Path(os.path.normpath(file_path))
-        if not normalized_path.exists() or not str(normalized_path).startswith(str(safe_root)):
+        normalized_path = Path(file_path).resolve()
+        if not normalized_path.exists() or not normalized_path.is_relative_to(safe_root):
             raise HTTPException(status_code=400, detail="Invalid or unsafe file path")
         # Override config with request parameters
         config.doctype = request.doctype  # String will be used directly

--- a/raft_toolkit/web/app.py
+++ b/raft_toolkit/web/app.py
@@ -286,12 +286,14 @@ async def get_preview(
     request: PreviewRequest,
     file_path: str,
     config: RaftConfig = Depends(get_raft_config),
+    safe_root: Path = Path("/safe/root/directory"),
 ):
     """Get a preview of what would be processed."""
     try:
         # Validate file exists
-        if not Path(file_path).exists():
-            raise HTTPException(status_code=400, detail="File not found")
+        normalized_path = Path(os.path.normpath(file_path))
+        if not normalized_path.exists() or not str(normalized_path).startswith(str(safe_root)):
+            raise HTTPException(status_code=400, detail="Invalid or unsafe file path")
         # Override config with request parameters
         config.doctype = request.doctype  # String will be used directly
         config.chunk_size = request.chunk_size


### PR DESCRIPTION
Potential fix for [https://github.com/MakerCorn/raft-toolkit/security/code-scanning/2046](https://github.com/MakerCorn/raft-toolkit/security/code-scanning/2046)

To fix the issue, we need to validate and sanitize the user-provided `file_path` before using it in path expressions. The best approach is to normalize the path using `os.path.normpath` and ensure it is contained within a predefined safe root directory. This prevents directory traversal attacks and ensures the path is safe to use.

Changes to implement:
1. Introduce a safe root directory (e.g., `/safe/root/directory`) in the `get_preview` method of `raft_toolkit/web/app.py`.
2. Normalize the `file_path` using `os.path.normpath` and check that the resulting path starts with the safe root directory.
3. Update the `get_processing_preview` method in `raft_toolkit/core/raft_engine.py` to handle the validated path correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
